### PR TITLE
better variable names provided by code generators

### DIFF
--- a/src/main/java/net/haesleinhuepf/clijx/assistant/scriptgenerator/AbstractScriptGenerator.java
+++ b/src/main/java/net/haesleinhuepf/clijx/assistant/scriptgenerator/AbstractScriptGenerator.java
@@ -2,17 +2,27 @@ package net.haesleinhuepf.clijx.assistant.scriptgenerator;
 
 import ij.ImagePlus;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clijx.assistant.AbstractAssistantGUIPlugin;
 import net.haesleinhuepf.clijx.assistant.ScriptGenerator;
 import net.haesleinhuepf.clijx.assistant.services.AssistantGUIPlugin;
+import net.haesleinhuepf.clijx.assistant.utilities.AssistantUtilities;
 import net.haesleinhuepf.spimcat.io.CLIJxVirtualStack;
 
 import java.util.HashMap;
+import java.util.Locale;
 
 public abstract class AbstractScriptGenerator implements ScriptGenerator {
     protected HashMap<ImagePlus, String> image_map = new HashMap<>();
     public String makeImageID(ImagePlus target) {
         if (!image_map.keySet().contains(target)) {
-            image_map.put(target, "image" + (image_map.size() + 1));
+            String name = "result_image_" + (image_map.size() + 1);
+
+            AssistantGUIPlugin pluginFromTargetImage = AbstractAssistantGUIPlugin.getPluginFromTargetImage(target);
+            if (pluginFromTargetImage != null) {
+                name = "result_" + AssistantUtilities.niceName(pluginFromTargetImage.getName()).toLowerCase().replace(" ", "_") + "_" + (image_map.size() + 1);
+            }
+
+            image_map.put(target, name);
         }
 
         return image_map.get(target);

--- a/src/main/java/net/haesleinhuepf/clijx/assistant/scriptgenerator/AbstractScriptGenerator.java
+++ b/src/main/java/net/haesleinhuepf/clijx/assistant/scriptgenerator/AbstractScriptGenerator.java
@@ -15,11 +15,11 @@ public abstract class AbstractScriptGenerator implements ScriptGenerator {
     protected HashMap<ImagePlus, String> image_map = new HashMap<>();
     public String makeImageID(ImagePlus target) {
         if (!image_map.keySet().contains(target)) {
-            String name = "result_image_" + (image_map.size() + 1);
+            String name = "image_" + (image_map.size() + 1);
 
             AssistantGUIPlugin pluginFromTargetImage = AbstractAssistantGUIPlugin.getPluginFromTargetImage(target);
             if (pluginFromTargetImage != null) {
-                name = "result_" + AssistantUtilities.niceName(pluginFromTargetImage.getName()).toLowerCase().replace(" ", "_") + "_" + (image_map.size() + 1);
+                name = "image_" + AssistantUtilities.niceName(pluginFromTargetImage.getName()).toLowerCase().replace(" ", "_") + "_" + (image_map.size() + 1);
             }
 
             image_map.put(target, name);


### PR DESCRIPTION
Hi @tischi,

here comes a suggestion for better image variable names. Instead of "image3" it now generates a name such as "result_threshold_otsu_3". You can try it out by installing 
[clijx-assistant_-0.4.2.25-tischi.jar.zip](https://github.com/clij/assistant/files/6228747/clijx-assistant_-0.4.2.25-tischi.jar.zip)

closes #50 

Let me know what you think! If you like, I can also make you collaborator and you can change the code section I just edited for this PR.

Thanks!

Cheers,
Robert
